### PR TITLE
[MCC-339647] Handle circular references when resolving

### DIFF
--- a/lib/open_api_parser/pointer.rb
+++ b/lib/open_api_parser/pointer.rb
@@ -12,7 +12,9 @@ module OpenApiParser
       end
     end
 
-    private
+    def exists_in_path?(path)
+      path.include?(escaped_pointer)
+    end
 
     def escaped_pointer
       if @raw_pointer.start_with?("#")
@@ -21,6 +23,8 @@ module OpenApiParser
         @raw_pointer
       end
     end
+
+    private
 
     def parse_token(token)
       if token =~ /\A\d+\z/
@@ -32,11 +36,7 @@ module OpenApiParser
 
     def tokens
       tokens = escaped_pointer[1..-1].split("/")
-
-      if @raw_pointer.end_with?("/")
-        tokens << ""
-      end
-
+      tokens << "" if @raw_pointer.end_with?("/")
       tokens.map do |token|
         parse_token(token)
       end

--- a/spec/open_api_parser/specification_spec.rb
+++ b/spec/open_api_parser/specification_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe OpenApiParser::Specification do
         specification = OpenApiParser::Specification.resolve(path)
 
         expect(specification.raw.fetch("swagger")).to eq("2.0")
-        expect(specification.raw.dig("definitions", "animalHierarchyDescendants")).to eq(expanded_descendents)
-        expect(specification.raw.dig("definitions", "animalHierarchy")).to eq(expanded_hierarchy)
+        expect(specification.raw.fetch("definitions").fetch("animalHierarchyDescendants")).to eq(expanded_descendents)
+        expect(specification.raw.fetch("definitions").fetch("animalHierarchy")).to eq(expanded_hierarchy)
       end
     end
 

--- a/spec/open_api_parser/specification_spec.rb
+++ b/spec/open_api_parser/specification_spec.rb
@@ -9,12 +9,44 @@ RSpec.describe OpenApiParser::Specification do
 
         expect(specification.raw.fetch("swagger")).to eq("2.0")
       end
+    end
 
-      it "allows skipping meta schema validation" do
-        expect do
-          path = File.expand_path("../../resources/pointer_example.yaml", __FILE__)
-          OpenApiParser::Specification.resolve(path, validate_meta_schema: false)
-        end.to_not raise_error
+    context "valid specification containing a circular reference" do
+      it "resolves successfully and stops expanding references if they are circular" do
+        expanded_descendents = {
+          "type" => "object",
+          "properties" => {
+            "name" => {
+              "type" => "string"
+            },
+            "descendants" => {
+              "type" => "array",
+              "items" => {
+                "$ref" => "#/definitions/animalHierarchyDescendants"
+              }
+            }
+          }
+        }
+
+        expanded_hierarchy = {
+          "type" => "object",
+          "properties" => {
+            "name" => {
+              "type" => "string"
+            },
+            "descendants" => {
+              "type" => "array",
+              "items" => expanded_descendents
+            }
+          }
+        }
+
+        path = File.expand_path("../../resources/valid_with_cycle_spec.yaml", __FILE__)
+        specification = OpenApiParser::Specification.resolve(path)
+
+        expect(specification.raw.fetch("swagger")).to eq("2.0")
+        expect(specification.raw.dig("definitions", "animalHierarchyDescendants")).to eq(expanded_descendents)
+        expect(specification.raw.dig("definitions", "animalHierarchy")).to eq(expanded_hierarchy)
       end
     end
 
@@ -37,6 +69,13 @@ RSpec.describe OpenApiParser::Specification do
           JSON::Schema::ValidationError,
           /contains additional properties \[\"fake-http-method\"\] outside of the schema/
         )
+      end
+
+      it "allows skipping meta schema validation" do
+        expect do
+          path = File.expand_path("../../resources/invalid_spec.yaml", __FILE__)
+          OpenApiParser::Specification.resolve(path, validate_meta_schema: false)
+        end.to_not raise_error
       end
     end
   end

--- a/spec/resources/valid_with_cycle_spec.yaml
+++ b/spec/resources/valid_with_cycle_spec.yaml
@@ -1,0 +1,121 @@
+swagger: "2.0"
+
+info:
+  title: Simple API overview
+  version: "1"
+
+produces:
+  - application/json
+consumes:
+  - application/json
+
+definitions:
+  createAnimal:
+    type: object
+    required:
+      - name
+      - legs
+    properties:
+      name:
+        type: string
+      legs:
+        type: integer
+
+  validResponse:
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        type: string
+        enum:
+          - ok
+
+  errorResponse:
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        type: string
+        enum:
+          - bad
+
+  animalHierarchy:
+    type: object
+    properties:
+      descendants:
+        type: array
+        items:
+          $ref: '#/definitions/animalHierarchyDescendants'
+      name:
+        type: string
+
+  animalHierarchyDescendants:
+    type: object
+    properties:
+      descendants:
+        type: array
+        items:
+          $ref: '#/definitions/animalHierarchyDescendants'
+      name:
+        type: string
+
+paths:
+  /animals:
+    post:
+      operationId: createAnimal
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/createAnimal"
+      responses:
+        201:
+          description: Valid create
+          schema:
+            $ref: "#/definitions/validResponse"
+        default:
+          description: Error response
+          schema:
+            $ref: "#/definitions/errorResponse"
+
+  /animals/{id}:
+    get:
+      operationId: getAnimal
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+      responses:
+        200:
+          description: Valid get animal
+          schema:
+            $ref: "#/definitions/validResponse"
+        default:
+          description: Error response
+          schema:
+            $ref: "#/definitions/errorResponse"
+
+  /animals/{id}/hierarchy:
+    get:
+      operationId: getAnimalHierarchy
+      description: View the ancestors and descendants hierarchy for a given animal
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+      responses:
+        200:
+          description: Valid get animal hierarchy
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/animalHierarchy'
+        default:
+          description: Error response
+          schema:
+            $ref: "#/definitions/errorResponse"


### PR DESCRIPTION
Note that this PR is building on top of the `ssteeg-mdsol:feature/json-schema` branch from https://github.com/braintree/open_api_parser/pull/9

This PR handles circular references within a spec. If it determines that the ref already exists in the `cur_path`, it stops expanding the ref and just returns it as is.

@jfeltesse-mdsol @jcarres-mdsol @ykitamura-mdsol